### PR TITLE
Vec ext

### DIFF
--- a/gaei_cpp/meta.hpp
+++ b/gaei_cpp/meta.hpp
@@ -1,0 +1,61 @@
+﻿#pragma once
+#include <type_traits>
+
+namespace gaei {
+inline namespace detail {
+
+#define GAEI_IS_OPERATABLE(name, op)\
+template<class T, class = void>\
+struct name : std::false_type {};\
+template<class T>\
+struct name <T, std::void_t<decltype(std::declval<T&>() op std::declval<T&>())>>\
+    : std::true_type{};\
+template<class T>\
+constexpr bool name ## _v = name <T>:: value;
+
+GAEI_IS_OPERATABLE(is_addable, +)
+
+GAEI_IS_OPERATABLE(is_multipliable, *)
+
+GAEI_IS_OPERATABLE(is_subtractable, -)
+
+GAEI_IS_OPERATABLE(is_divisible, /)
+
+#undef GAEI_IS_OPERATABLE
+
+#define GAEI_HAS_MEMBER(member_name)\
+template<class T, class = void>\
+struct has_member_ ## member_name : std::false_type {};\
+\
+template<class T>\
+struct has_member_ ## member_name<T, std::void_t<decltype(&(T::member_name))>> : std::true_type {};\
+template<class T>\
+inline constexpr bool has_member_ ## member_name ## _v = has_member_ ## member_name <T>::value;
+
+GAEI_HAS_MEMBER(write)
+
+#undef GAEI_HAS_MEMBER
+
+#define GAEI_HAS_MEMBER_TYPE(type_name)\
+template<class T, class = void>\
+struct has_ ## type_name : std::false_type {};\
+template<class T>\
+struct has_ ## type_name <T, std::void_t<typename T::type_name>> : std::true_type {};\
+template<class T>\
+constexpr bool has_ ## type_name ## _v = has_ ## type_name <T>::value;
+
+GAEI_HAS_MEMBER_TYPE(value_type)
+
+#undef GAEI_HAS_MEMBER_TYPE
+
+// because we use c++17, we cannot use `std::remove_cvref` that will be available from c++20.
+template<class T>
+struct remove_cvref {
+    using type = std::remove_cv_t<std::remove_reference_t<T>>;
+};
+template<class T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+
+
+}   // namespace detail
+}   // namespace gaei

--- a/gaei_cpp/vector_utl.hpp
+++ b/gaei_cpp/vector_utl.hpp
@@ -13,11 +13,12 @@ T distance(const vector<T, Dim>& a,
            const vector<T, Dim>& b)
     noexcept
 {
+    using std::pow, std::sqrt;
     T sum{};
     for (auto i = 0u; i < Dim; ++i) {
-        sum += static_cast<T>(std::pow(a.coord[i] - b.coord[i], 2));
+        sum += static_cast<T>(pow(a.coord[i] - b.coord[i], 2));
     }
-    return static_cast<T>(std::sqrt(sum));
+    return static_cast<T>(sqrt(sum));
 }
 
 // ベクトルaとbの内積

--- a/gaei_cpp/vertex.hpp
+++ b/gaei_cpp/vertex.hpp
@@ -2,6 +2,7 @@
 #include <cstddef>
 #include <type_traits>
 #include "ouchilib/utl/multiitr.hpp"
+#include "meta.hpp"
 
 namespace gaei {
 

--- a/gaei_cpp/vertex.hpp
+++ b/gaei_cpp/vertex.hpp
@@ -6,49 +6,6 @@
 #include "meta.hpp"
 
 namespace gaei {
-namespace detail {
-
-template<class T, class = void>
-struct is_addable : std::false_type {};
-
-template<class T>
-struct is_addable<T, std::void_t<decltype(std::declval<T&>() + std::declval<T&>())>>
-    : std::true_type {};
-
-template<class T>
-constexpr bool is_addable_v = is_addable<T>::value;
-
-template<class T, class = void>
-struct is_multipliable : std::false_type {};
-
-template<class T>
-struct is_multipliable<T, std::void_t<decltype(std::declval<T&>() * std::declval<T&>())>>
-    : std::true_type {};
-
-template<class T>
-constexpr bool is_multipliable_v = is_multipliable<T>::value;
-
-template<class T, class = void>
-struct is_subtractable : std::false_type {};
-
-template<class T>
-struct is_subtractable<T, std::void_t<decltype(std::declval<T&>() - std::declval<T&>())>>
-    : std::true_type {};
-
-template<class T>
-constexpr bool is_subtractable_v = is_subtractable<T>::value;
-
-template<class T, class = void>
-struct is_divisible : std::false_type {};
-
-template<class T>
-struct is_divisible<T, std::void_t<decltype(std::declval<T&>() / std::declval<T&>())>>
-    : std::true_type {};
-
-template<class T>
-constexpr bool is_divisible_v = is_divisible<T>::value;
-}   // namespace detail
-
 
 /// <summary>
 /// 点を表現します。

--- a/gaei_cpp/vertex.hpp
+++ b/gaei_cpp/vertex.hpp
@@ -2,7 +2,6 @@
 #include <cstddef>
 #include <type_traits>
 #include "ouchilib/utl/multiitr.hpp"
-#include "meta.hpp"
 
 namespace gaei {
 
@@ -12,11 +11,7 @@ namespace gaei {
 /// <typeparam name="T">点の各次元の型</typeparam>
 template<class T, std::size_t Dim>
 struct vector {
-    static_assert(detail::is_addable_v<T>&&
-                  detail::is_subtractable_v<T>&&
-                  detail::is_multipliable_v<T>&&
-                  detail::is_divisible_v<T>);
-    static_assert(Dim > 0);
+    static_assert(std::is_arithmetic_v<T>);
     /// <summary>
     /// 点の各次元の座標を格納します。
     /// </summary>

--- a/gaei_cpp/vertex.hpp
+++ b/gaei_cpp/vertex.hpp
@@ -2,6 +2,7 @@
 #include <cstddef>
 #include <type_traits>
 #include "ouchilib/utl/multiitr.hpp"
+#include "meta.hpp"
 
 namespace gaei {
 
@@ -11,7 +12,11 @@ namespace gaei {
 /// <typeparam name="T">点の各次元の型</typeparam>
 template<class T, std::size_t Dim>
 struct vector {
-    static_assert(std::is_arithmetic_v<T>);
+    static_assert(detail::is_addable_v<T>&&
+                  detail::is_subtractable_v<T>&&
+                  detail::is_multipliable_v<T>&&
+                  detail::is_divisible_v<T>);
+    static_assert(Dim > 0);
     /// <summary>
     /// 点の各次元の座標を格納します。
     /// </summary>

--- a/gaei_cpp/vertex.hpp
+++ b/gaei_cpp/vertex.hpp
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #include <cstddef>
 #include <type_traits>
+#include "color.hpp"
 #include "ouchilib/utl/multiitr.hpp"
 
 namespace gaei {
@@ -145,9 +146,9 @@ struct vector {
 using vec2f = vector<float, 2>;
 using vec3f = vector<float, 3>;
 
-template<class PosT, class ColorT>
+template<class PosT = vec3f, class ColorT = color>
 struct vertex {
-    PosT position;
+    PosT position = PosT{};
     ColorT color = ColorT{};
 };
 

--- a/gaei_cpp/vertex.hpp
+++ b/gaei_cpp/vertex.hpp
@@ -4,6 +4,49 @@
 #include "ouchilib/utl/multiitr.hpp"
 
 namespace gaei {
+namespace detail {
+
+template<class T, class = void>
+struct is_addable : std::false_type {};
+
+template<class T>
+struct is_addable<T, std::void_t<decltype(std::declval<T&>() + std::declval<T&>())>>
+    : std::true_type {};
+
+template<class T>
+constexpr bool is_addable_v = is_addable<T>::value;
+
+template<class T, class = void>
+struct is_multipliable : std::false_type {};
+
+template<class T>
+struct is_multipliable<T, std::void_t<decltype(std::declval<T&>() * std::declval<T&>())>>
+    : std::true_type {};
+
+template<class T>
+constexpr bool is_multipliable_v = is_multipliable<T>::value;
+
+template<class T, class = void>
+struct is_subtractable : std::false_type {};
+
+template<class T>
+struct is_subtractable<T, std::void_t<decltype(std::declval<T&>() - std::declval<T&>())>>
+    : std::true_type {};
+
+template<class T>
+constexpr bool is_subtractable_v = is_subtractable<T>::value;
+
+template<class T, class = void>
+struct is_divisible : std::false_type {};
+
+template<class T>
+struct is_divisible<T, std::void_t<decltype(std::declval<T&>() / std::declval<T&>())>>
+    : std::true_type {};
+
+template<class T>
+constexpr bool is_divisible_v = is_divisible<T>::value;
+}   // namespace detail
+
 
 /// <summary>
 /// 点を表現します。
@@ -11,8 +54,16 @@ namespace gaei {
 /// <typeparam name="T">点の各次元の型</typeparam>
 template<class T, std::size_t Dim>
 struct vector {
-    static_assert(std::is_arithmetic_v<T>);
+    // 四則演算が可能か？
+    static_assert(detail::is_addable_v<T> &&
+                  detail::is_multipliable_v<T> &&
+                  detail::is_subtractable_v<T> &&
+                  detail::is_divisible_v<T>);
+    // 次元は0より大きいか？
     static_assert(Dim > 0);
+
+    using value_type = T;
+    static constexpr size_t dimension = Dim;
 
     /// <summary>
     /// 点の各次元の座標を格納します。

--- a/gaei_cpp/vertex.hpp
+++ b/gaei_cpp/vertex.hpp
@@ -12,7 +12,7 @@ namespace gaei {
 template<class T, std::size_t Dim>
 struct vector {
     static_assert(std::is_arithmetic_v<T>);
-    static_assert(Dim > 0)
+    static_assert(Dim > 0);
 
     /// <summary>
     /// 点の各次元の座標を格納します。

--- a/gaei_cpp/vertex.hpp
+++ b/gaei_cpp/vertex.hpp
@@ -12,13 +12,15 @@ namespace gaei {
 template<class T, std::size_t Dim>
 struct vector {
     static_assert(std::is_arithmetic_v<T>);
+    static_assert(Dim > 0)
+
     /// <summary>
     /// 点の各次元の座標を格納します。
     /// </summary>
     T coord[Dim];
 
     /// <summary>
-    /// 点が1次元以上である場合のみ有効です。点のx座標への参照を返します。
+    /// プログラムがwell-formedであるとき常に有効です。点のx座標への参照を返します。
     /// </summary>
     template<size_t D = Dim, std::enable_if_t<(D >= 1)>* = nullptr>
     [[nodiscard]]
@@ -28,6 +30,7 @@ struct vector {
     constexpr const T& x() const noexcept { return coord[0]; };
     /// <summary>
     /// 点が2次元以上である場合のみ有効です。点のy座標への参照を返します。
+    /// 点が2次元未満であるときこのメソッドは実体化に失敗します。
     /// </summary>
     template<size_t D = Dim, std::enable_if_t<(D >= 2)>* = nullptr>
     [[nodiscard]]
@@ -37,6 +40,7 @@ struct vector {
     constexpr const T& y() const noexcept { return coord[1]; };
     /// <summary>
     /// 点が3次元以上である場合のみ有効です。点のz座標への参照を返します。
+    /// 点が3次元未満であるときこのメソッドは実体化に失敗します。
     /// </summary>
     template<size_t D = Dim, std::enable_if_t<(D >= 3)>* = nullptr>
     [[nodiscard]]
@@ -45,6 +49,24 @@ struct vector {
     [[nodiscard]]
     constexpr const T& z() const noexcept { return coord[2]; };
 
+    [[nodiscard]]
+    static constexpr vector zero() noexcept { return vector{}; }
+
+    [[nodiscard]]
+    friend constexpr bool operator< (const vector& lhs, const vector& rhs) noexcept
+    {
+        for (auto [l, r] : ouchi::multiitr{ lhs.coord, rhs.coord }) {
+            if (l == r) continue;
+            else return l < r;
+        }
+        return false;
+    }
+    [[nodiscard]]
+    friend constexpr bool operator> (const vector& lhs, const vector& rhs) noexcept
+    {
+        return rhs < lhs;
+    }
+    [[nodiscard]]
     friend constexpr bool operator== (const vector& lhs, const vector& rhs) noexcept
     {
         for (auto [l, r] : ouchi::multiitr{ lhs.coord, rhs.coord }) {
@@ -52,9 +74,20 @@ struct vector {
         }
         return true;
     }
+    [[nodiscard]]
     friend constexpr bool operator!= (const vector& lhs, const vector& rhs) noexcept
     {
         return !(lhs == rhs);
+    }
+    [[nodiscard]]
+    friend constexpr bool operator<= (const vector& lhs, const vector& rhs) noexcept
+    {
+        return (lhs < rhs) || (lhs == rhs);
+    }
+    [[nodiscard]]
+    friend constexpr bool operator>= (const vector& lhs, const vector& rhs) noexcept
+    {
+        return (lhs > rhs) || (lhs == rhs);
     }
 };
 

--- a/gaei_cpp/vertex.hpp
+++ b/gaei_cpp/vertex.hpp
@@ -104,6 +104,9 @@ struct vector {
     [[nodiscard]]
     static constexpr vector zero() noexcept { return vector{}; }
 
+    /// <summary>
+    /// 辞書順に並べたときlhsがrhsより前より来るならばtrue。それ以外はfalse
+    /// </summary>
     [[nodiscard]]
     friend constexpr bool operator< (const vector& lhs, const vector& rhs) noexcept
     {

--- a/gaei_cpp/vrml_writer.hpp
+++ b/gaei_cpp/vrml_writer.hpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <memory>
 #include <filesystem>
+#include <variant>  // for std::monostate
 
 #include"color.hpp"
 #include"vertex.hpp"
@@ -172,7 +173,7 @@ struct texture_transform {
     }
 };
 
-template<class Texture = std::nullptr_t>
+template<class Texture = std::monostate>
 struct appearance {
     material mate;
     Texture texture = Texture{};

--- a/gaei_cpp/vrml_writer.hpp
+++ b/gaei_cpp/vrml_writer.hpp
@@ -6,23 +6,13 @@
 #include <memory>
 #include <filesystem>
 
-#include"color.hpp"
-#include"vertex.hpp"
+#include "color.hpp"
+#include "vertex.hpp"
+#include "meta.hpp"
 
 namespace gaei::vrml {
 
 namespace detail {
-
-#define GAEI_HAS_MEMBER(member_name)\
-template<class T, class = void>\
-struct has_member_ ## member_name : std::false_type {};\
-\
-template<class T>\
-struct has_member_ ## member_name<T, std::void_t<decltype(&(T:: ## member_name))>> : std::true_type {};\
-template<class T>\
-inline constexpr bool has_member_ ## member_name ## _v = has_member_ ## member_name <T>::value;
-
-GAEI_HAS_MEMBER(write);
 
 template<class T, class ...Printable>
 bool write_if_different(const T& default_value,
@@ -35,8 +25,7 @@ bool write_if_different(const T& default_value,
     (out << ... << pt);
     return true;
 }
-
-}
+}// namespace detail
 
 struct node_base {
     virtual ~node_base() = default;
@@ -179,7 +168,7 @@ struct appearance {
     texture_transform transform = texture_transform{};
     template<
         class T = Texture,
-        std::enable_if_t<detail::has_member_write_v<T>>* = nullptr>
+        std::enable_if_t<gaei::detail::has_member_write_v<T>>* = nullptr>
         bool write(std::ostream& out) const
     {
         out << "appearance Appearance {\n";
@@ -191,7 +180,7 @@ struct appearance {
     }
     template<
         class T = Texture,
-        std::enable_if_t<! detail::has_member_write_v<T>>* = nullptr>
+        std::enable_if_t<! gaei::detail::has_member_write_v<T>>* = nullptr>
     bool write(std::ostream& out) const
     {
         out << "appearance Appearance {\n";

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+﻿cmake_minimum_required (VERSION 3.8)
 
 project ("gaei_cpp")
 

--- a/test/test_vec_utl.cpp
+++ b/test/test_vec_utl.cpp
@@ -4,17 +4,17 @@
 OUCHI_TEST_CASE(test_distance)
 {
     {
-        gaei::vector<int, 2> a{ 0, 0 };
+        constexpr auto zero = gaei::vector<int, 2>::zero();
         gaei::vector<int, 2> b{ 3, 0 };
 
         // distance(a, b) が 3と等しいか調べる。
-        OUCHI_CHECK_EQUAL(gaei::distance(a, b), 3);
+        OUCHI_CHECK_EQUAL(gaei::distance(zero, b), 3);
     }
     {
-        gaei::vector<double, 3> a{ 0, 0, 0 };
+        constexpr auto zero = gaei::vector<double, 3>::zero();
         gaei::vector<double, 3> b{ 3, 0, 4 };
 
-        OUCHI_CHECK_EQUAL(gaei::distance(a, b), 5);
+        OUCHI_CHECK_EQUAL(gaei::distance(zero, b), 5);
     }
 }
 

--- a/test/test_vertex.cpp
+++ b/test/test_vertex.cpp
@@ -7,3 +7,21 @@ OUCHI_TEST_CASE(test_vector_instantiate)
     v2.y() = 0;
     OUCHI_CHECK_EQUAL(v2.coord[1], 0);
 }
+
+OUCHI_TEST_CASE(test_vector_order)
+{
+    {
+        gaei::vec2f v1{ 0, 100 };
+        gaei::vec2f v2{ 1, 0 };
+        OUCHI_CHECK_TRUE(v1 < v2);
+        OUCHI_CHECK_TRUE(v2 > v1);
+        OUCHI_CHECK_TRUE(v1 != v2);
+    }
+    {
+        gaei::vec2f v1{ 2, 10 };
+        gaei::vec2f v2{ 2,20 };
+        OUCHI_CHECK_TRUE(v1 < v2);
+        OUCHI_CHECK_TRUE(v2 > v1);
+        OUCHI_CHECK_TRUE(v1 != v2);
+    }
+}


### PR DESCRIPTION
- `gaei::vector`のテンプレートパラメータ`T`に四則演算が定義されている型ならば組み込み算術型でなくても指定できるよう修正。

- `gaei::vector`にメンバ型`value_type`とメンバ定数`dimension`を追加。

- `gaei::vector`に比較演算子を追加 (x座標から順番に見て辞書順の比較を行う)。

- `gaei::vertex`にデフォルトのテンプレート引数を追加。
    `gaei::vertex<>`が`gaei::vertex<gaei::vec3f, gaei::color>`と同じ意味に。

- テクスチャを使用しない`gaei::vrml::appearance`のサイズが減少 (無駄なサイズが8 byteから最大1 byteまで減少)。